### PR TITLE
cabal: bump upper bound on vector-space.

### DIFF
--- a/combobuffer.cabal
+++ b/combobuffer.cabal
@@ -29,7 +29,7 @@ Library
                      -- ,type-level   >= 0.2    && < 0.3
                      -- ,tuple        >= 0.2    && < 0.3
                      ,vector       >= 0.5    && < 0.11
-                     ,vector-space >= 0.7    && < 0.9
+                     ,vector-space >= 0.7    && < 0.10
   
 source-repository head
   type:                git


### PR DESCRIPTION
vector-space 0.9 doesn’t build on GHC 7.10 due to ambiguous references. This is fixed by vector-space 0.10, with which combobuffer seems to build just fine.
