### PR TITLE
Support template-haskell 2.11, bump dependency bounds

### DIFF
--- a/combobuffer.cabal
+++ b/combobuffer.cabal
@@ -28,8 +28,8 @@ Library
                      ,template-haskell
                      -- ,type-level   >= 0.2    && < 0.3
                      -- ,tuple        >= 0.2    && < 0.3
-                     ,vector       >= 0.5    && < 0.11
-                     ,vector-space >= 0.7    && < 0.9
+                     ,vector       >= 0.5    && < 0.12
+                     ,vector-space >= 0.7    && < 0.11
   
 source-repository head
   type:                git

--- a/src/Data/RingBuffer/TGen.hs
+++ b/src/Data/RingBuffer/TGen.hs
@@ -36,8 +36,13 @@ mkVec elname binders prefix sz = do
   return $ concat [d1,d2,d3,d4]
 
 decTN sz nm elname binders =
+#if MIN_VERSION_template_haskell(2,11,0)
+  let fields = replicate sz (Bang NoSourceUnpackedness SourceStrict, elname)
+  in return [DataD [] nm binders Nothing [NormalC nm fields] []]
+#else
   let fields = replicate sz (IsStrict, elname)
   in return [DataD [] nm binders [NormalC nm fields] []]
+#endif
 
 #if MIN_VERSION_template_haskell(2,9,0)
 mkElInst tname elname = return [TySynInstD ''El $ TySynEqn [tname] (elname) ]


### PR DESCRIPTION
Some fixes required when building using GHC 8.
